### PR TITLE
`multiparts/form`で過去に発生したCVEの対策設定

### DIFF
--- a/formstream.go
+++ b/formstream.go
@@ -7,29 +7,35 @@ import (
 )
 
 type Parser struct {
-	boundary       string
-	maxMemFileSize DataSize
-	valueMap       map[string][]Value
-	hookMap        map[string]streamHook
+	boundary string
+	valueMap map[string][]Value
+	hookMap  map[string]streamHook
+	parserConfig
 }
 
 func NewParser(boundary string, options ...ParserOption) *Parser {
-	c := &parserConfig{
+	c := parserConfig{
+		maxParts:       defaultMaxParts,
+		maxHeaders:     defaultMaxHeaders,
+		maxMemSize:     defaultMaxMemSize,
 		maxMemFileSize: defaultMaxMemFileSize,
 	}
 	for _, opt := range options {
-		opt(c)
+		opt(&c)
 	}
 
 	return &Parser{
-		boundary:       boundary,
-		maxMemFileSize: c.maxMemFileSize,
-		valueMap:       make(map[string][]Value),
-		hookMap:        make(map[string]streamHook),
+		boundary:     boundary,
+		valueMap:     make(map[string][]Value),
+		hookMap:      make(map[string]streamHook),
+		parserConfig: c,
 	}
 }
 
 type parserConfig struct {
+	maxParts       uint
+	maxHeaders     uint
+	maxMemSize     DataSize
 	maxMemFileSize DataSize
 }
 
@@ -44,7 +50,30 @@ const (
 	GB
 )
 
-const defaultMaxMemFileSize = 32 * MB
+const (
+	defaultMaxParts       = 10000
+	defaultMaxHeaders     = 10000
+	defaultMaxMemSize     = 32 * MB
+	defaultMaxMemFileSize = 32 * MB
+)
+
+func WithMaxParts(maxParts uint) ParserOption {
+	return func(c *parserConfig) {
+		c.maxParts = maxParts
+	}
+}
+
+func WithMaxHeaders(maxHeaders uint) ParserOption {
+	return func(c *parserConfig) {
+		c.maxHeaders = maxHeaders
+	}
+}
+
+func WithMaxMemSize(maxMemSize DataSize) ParserOption {
+	return func(c *parserConfig) {
+		c.maxMemSize = maxMemSize
+	}
+}
 
 func WithMaxMemFileSize(maxMemFileSize DataSize) ParserOption {
 	return func(c *parserConfig) {

--- a/parse_test.go
+++ b/parse_test.go
@@ -123,6 +123,108 @@ func TestParser_Parse(t *testing.T) {
 			},
 			err: errTest,
 		},
+		{
+			name: "too many parts",
+			inputFormData: "--boundary\n" +
+				"Content-Disposition: form-data; name=\"field1\"\n" +
+				"\n" +
+				"field1Value\n" +
+				"--boundary\n" +
+				"Content-Disposition: form-data; name=\"field2\"\n" +
+				"\n" +
+				"field2Value\n" +
+				"--boundary\n" +
+				"Content-Disposition: form-data; name=\"field3\"\n" +
+				"\n" +
+				"field3Value\n" +
+				"--boundary\n" +
+				"Content-Disposition: form-data; name=\"field4\"\n" +
+				"\n" +
+				"field4Value\n" +
+				"--boundary\n" +
+				"Content-Disposition: form-data; name=\"field5\"\n" +
+				"\n" +
+				"field5Value\n" +
+				"--boundary\n" +
+				"Content-Disposition: form-data; name=\"field6\"\n" +
+				"\n" +
+				"field6Value\n" +
+				"--boundary--\n",
+			outputValueMap: map[string][]Value{
+				"field1": {
+					{
+						content: []byte("field1Value"),
+						header:  newHeader(map[string][]string{"Content-Disposition": {"form-data; name=\"field1\""}}),
+					},
+				},
+				"field2": {
+					{
+						content: []byte("field2Value"),
+						header:  newHeader(map[string][]string{"Content-Disposition": {"form-data; name=\"field2\""}}),
+					},
+				},
+				"field3": {
+					{
+						content: []byte("field3Value"),
+						header:  newHeader(map[string][]string{"Content-Disposition": {"form-data; name=\"field3\""}}),
+					},
+				},
+				"field4": {
+					{
+						content: []byte("field4Value"),
+						header:  newHeader(map[string][]string{"Content-Disposition": {"form-data; name=\"field4\""}}),
+					},
+				},
+				"field5": {
+					{
+						content: []byte("field5Value"),
+						header:  newHeader(map[string][]string{"Content-Disposition": {"form-data; name=\"field5\""}}),
+					},
+				},
+			},
+			mockSetup: func(m *mock.MockIConditionJudger[string, *normalParam, *abnormalParam]) {
+				m.EXPECT().IsHookExist("field1").Return(false)
+				m.EXPECT().KeyEvent("field1").Return(nil)
+				m.EXPECT().IsHookExist("field2").Return(false)
+				m.EXPECT().KeyEvent("field2").Return(nil)
+				m.EXPECT().IsHookExist("field3").Return(false)
+				m.EXPECT().KeyEvent("field3").Return(nil)
+				m.EXPECT().IsHookExist("field4").Return(false)
+				m.EXPECT().KeyEvent("field4").Return(nil)
+				m.EXPECT().IsHookExist("field5").Return(false)
+				m.EXPECT().KeyEvent("field5").Return(nil)
+			},
+			err: ErrTooManyParts,
+		},
+		{
+			name: "too many headers",
+			inputFormData: "--boundary\n" +
+				"Content-Disposition: form-data; name=\"field1\"\n" +
+				"a: field2\n" +
+				"b: field3\n" +
+				"c: field4\n" +
+				"d: field5\n" +
+				"e: field6\n" +
+				"\n" +
+				"field1Value\n" +
+				"--boundary--\n",
+			outputValueMap: map[string][]Value{},
+			mockSetup:      func(m *mock.MockIConditionJudger[string, *normalParam, *abnormalParam]) {},
+			err:            ErrTooManyHeaders,
+		},
+		{
+			name: "too large form",
+			inputFormData: "--boundary\n" +
+				"Content-Disposition: form-data; name=\"field1\"\n" +
+				"\n" +
+				strings.Repeat("a", 1024) + "\n" +
+				"--boundary--\n",
+			outputValueMap: map[string][]Value{},
+			mockSetup: func(m *mock.MockIConditionJudger[string, *normalParam, *abnormalParam]) {
+				m.EXPECT().IsHookExist("field1").Return(false)
+			},
+			err: ErrTooLargeForm,
+		},
 	}
 
 	for _, tc := range cases {
@@ -136,6 +238,12 @@ func TestParser_Parse(t *testing.T) {
 			parser := &Parser{
 				boundary: "boundary",
 				valueMap: make(map[string][]Value),
+				parserConfig: parserConfig{
+					maxParts:       5,
+					maxHeaders:     5,
+					maxMemSize:     1024,
+					maxMemFileSize: 1024,
+				},
 			}
 			err := parser.parse(strings.NewReader(tc.inputFormData), mockJudger)
 
@@ -280,7 +388,10 @@ func TestPreProcessor_run(t *testing.T) {
 			t.Parallel()
 
 			pp := &preProcessor{
-				maxMemFileSize: 32,
+				config: &parserConfig{
+					maxMemSize:     32,
+					maxMemFileSize: 32,
+				},
 			}
 
 			for i, readerType := range tt.readerTypes {

--- a/parse_test.go
+++ b/parse_test.go
@@ -209,7 +209,7 @@ func TestParser_Parse(t *testing.T) {
 				"field1Value\n" +
 				"--boundary--\n",
 			outputValueMap: map[string][]Value{},
-			mockSetup:      func(m *mock.MockIConditionJudger[string, *normalParam, *abnormalParam]) {},
+			mockSetup:      func(_ *mock.MockIConditionJudger[string, *normalParam, *abnormalParam]) {},
 			err:            ErrTooManyHeaders,
 		},
 		{


### PR DESCRIPTION
`multiparts/form`で過去に発生した[CVE-2023-24536](https://www.cve.org/CVERecord?id=CVE-2023-24536)、[CVE-2022-41725](https://www.cve.org/CVERecord?id=CVE-2022-41725)がformstreamでも起きうるものだったため、同様の対策を行った。

やったことは以下。
- 大きな値を送り付けることでメモリを使い果たす攻撃の対策としてメモリ使用量の上限を設定
  - デフォルト値は32GB
- 多数のpartやヘッダーを送り付けることで多数のオブジェクトを作りGCの負荷を上げサービスを落とす攻撃の対策として、part数、header数に上限設定
  - デフォルト値はいずれも`multiparts/form`と同様に10000