### PR TITLE
unwrap echo error

### DIFF
--- a/echo/parser.go
+++ b/echo/parser.go
@@ -1,6 +1,7 @@
 package echoform
 
 import (
+	"errors"
 	"io"
 	"mime"
 	"net/http"
@@ -32,6 +33,15 @@ func NewParser(c echo.Context, options ...formstream.ParserOption) (*Parser, err
 	}, nil
 }
 
+// Parse parses the request body.
+// It returns the echo.HTTPError if the hook function returns an echo.HTTPError.
 func (p *Parser) Parse() error {
-	return p.Parser.Parse(p.reader)
+	err := p.Parser.Parse(p.reader)
+
+	var httpErr *echo.HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr
+	}
+
+	return err
 }

--- a/gin/parser.go
+++ b/gin/parser.go
@@ -32,6 +32,7 @@ func NewParser(c *gin.Context, options ...formstream.ParserOption) (*Parser, err
 	}, nil
 }
 
+// Parse parses the request body.
 func (p *Parser) Parse() error {
 	return p.Parser.Parse(p.reader)
 }


### PR DESCRIPTION
Enabled to unwrap echo-specific errors.
This allows you to return the error status code directly within the hook.